### PR TITLE
feat: Redact Cache-Control max-age value

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"sync"
 	"time"
@@ -54,6 +55,7 @@ var stableHeaderKeys = []string{
 	"Via",
 	"Content-Security-Policy",
 }
+var cacheControlRegex = regexp.MustCompile(`(max-age=)(\d+)`)
 
 func main() {
 	outDir := flag.String("out", "data", "output directory for JSON, headers, status, and observed keys")
@@ -212,6 +214,9 @@ func writeHeaders(path string, hdrs http.Header) {
 	meta := make(map[string]string, len(stableHeaderKeys))
 	for _, k := range stableHeaderKeys {
 		if v := hdrs.Get(k); v != "" {
+			if k == "Cache-Control" {
+				v = cacheControlRegex.ReplaceAllString(v, "${1}[placeholder]")
+			}
 			meta[k] = v
 		}
 	}


### PR DESCRIPTION
The crawler was updated to handle dynamic Cache-Control headers by replacing the max-age value with a placeholder. This ensures that the logged headers are consistent across crawls, preventing unnecessary diffs.